### PR TITLE
Accuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added the accuser role - the selected player can check if a player is a hunter, at the price of his life.
+
 ## [1.3.4] - 2025-06-14
 
 ### Added

--- a/app/src/main/java/org/mystuff/McManhunt.java
+++ b/app/src/main/java/org/mystuff/McManhunt.java
@@ -13,6 +13,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -88,6 +89,10 @@ public class McManhunt extends JavaPlugin implements Listener {
                 chosenAccuser.sendMessage(ChatColor.RED + "You are the ACCUSER.");
                 chosenAccuser.sendMessage(ChatColor.YELLOW + "Use " + ChatColor.GOLD + "/accuse <player>" + ChatColor.YELLOW + " to expose a hunter.");
                 chosenAccuser.sendMessage(ChatColor.DARK_RED + "⚠ Wrong accusation = INSTANT DEATH.");
+                Location accuserLoc = chosenAccuser.getLocation();
+                if (accuserLoc != null) {
+                    chosenAccuser.playSound(accuserLoc, Sound.ENTITY_ENDER_DRAGON_GROWL, 1.0f, 1.0f);
+                }
             }
 
             for (Player p : hunted) {

--- a/app/src/main/resources/plugin.yml
+++ b/app/src/main/resources/plugin.yml
@@ -12,3 +12,6 @@ commands:
   tracknearest:
     description: Tracks the nearest player
     usage: /tracknearest
+  accuse:
+    description: Accuse a player of being a hunter. Wrong accusation will result in the death of the accuser.
+    usage: /accuse <playerName>


### PR DESCRIPTION
# Description

Created an `accuser` role - a randomly selected player which can accuse players of being the hunter.
But be wary, if the accuser guesses wrongly, he dies.
If he guesses correctly, the whole server will know who the hunter is.